### PR TITLE
Update tag to 1.1.5

### DIFF
--- a/charts/chia/1.0.0/test_values.yaml
+++ b/charts/chia/1.0.0/test_values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/chia-network/chia
-  tag: 1.1.4
+  tag: 1.1.5
   pullPolicy: IfNotPresent
 updateStrategy: Recreate
 environmentVariables:


### PR DESCRIPTION
Updated tag to most recent Chia release. This release contains important bug fixes.